### PR TITLE
Markdown syntax for links between CMS pages.

### DIFF
--- a/cmsplugin_simple_markdown/cms_plugins.py
+++ b/cmsplugin_simple_markdown/cms_plugins.py
@@ -2,14 +2,26 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from django.utils.translation import ugettext_lazy as _
 from cmsplugin_simple_markdown.models import SimpleMarkdownPlugin
+from cms.utils.page_resolver import get_page_from_path
+import re
 
 class SimpleMarkdownCMSPlugin(CMSPluginBase):
     model = SimpleMarkdownPlugin
     name = _('Simple Markdown')
     render_template = 'cmsplugin_simple_markdown/simple_markdown.html'
 
+    def replace_links(self, markdown_text):
+        def link_repl(match):
+            page = get_page_from_path(match.group(1))
+            if page:
+                return "(" + page.get_absolute_url() + ")"
+            else:
+                return "(#" + match.group(1) + ")"
+
+        return re.sub('\(page:([^\)]+)\)', link_repl, markdown_text)
+
     def render(self, context, instance, placeholder):
-        context['text'] = instance.markdown_text
+        context['text'] = self.replace_links(instance.markdown_text)
         return context
 
 plugin_pool.register_plugin(SimpleMarkdownCMSPlugin)


### PR DESCRIPTION
Added a simple regex to look for (page:BLAH) and use the "BLAH" to lookup the
cms page via it's path/slug. If there is a matching page it's absolute URL is
substituted.
