### PR TITLE
replaced django.contrib.markup with django-markdown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Configuration & Usage
 ----------------------
 
 1. Add ``cmsplugin_simple_markdown`` to  ``INSTALLED_APPS``.
-2. Add ``django.contrib.markup`` to ``INSTALLED_APPS``, if it isn't included already.
+2. Add ``django_markdown`` to ``INSTALLED_APPS``.
 3. Create the database tables::
 
     $ python manage.py migrate

--- a/README.rst
+++ b/README.rst
@@ -3,13 +3,18 @@ cmsplugin-simple-markdown
 =========================
 .. contents:: Table of contents
 
-Simple Markdown plugin is just an simple markdown plugin for django-cms.
+Simple Markdown plugin is just a simple markdown plugin for django-cms.
 It's brutally simple. Just a text area and you'll entered some markdown text and save it.
-And the reason why i make this is that, I really couldn't find any simple as stupid plugin
-for django-cms, all i've found was fancy with a lot of java script stuff.
+And the reason why I make this is that, I really couldn't find any simple as stupid plugin
+for django-cms, all I've found was fancy with a lot of java script stuff.
 
 
 
+Requirements
+=============
+
+- django-cms
+- django-markdown
 
 Installation
 ==============
@@ -71,7 +76,7 @@ Configuration & Usage
 ----------------------
 
 1. Add ``cmsplugin_simple_markdown`` to  ``INSTALLED_APPS``.
-2. Add ``django_markdown`` to ``INSTALLED_APPS``.
+2. If you are using Django 1.7 add ``'cmsplugin_simple_markdown': 'cmsplugin_simple_markdown.migrations_django',`` to ``MIGRATION_MODULES`` in settings.
 3. Create the database tables::
 
     $ python manage.py migrate
@@ -85,8 +90,8 @@ Drama story
 ===========
 Since every application won't begins with love, this plugin developed to solve a problem.
 2 days back, I've been using **cms.plugin.text** for handling html pages and related content,
-but when I've tried to use aws s3/cloudfront for my static files, i've stuck with ``CORS`` problem.
-So i've develop ``cmsplugin-simple-markdown`` to be used without any deps on js/css files.
+but when I've tried to use aws s3/cloudfront for my static files, I've stuck with ``CORS`` problem.
+So I've develop ``cmsplugin-simple-markdown`` to be used without any deps on js/css files.
 
-Now these days, people all around the world are using it, They are happy with it, They go creazy with ``cmsplugin-simple-markdown``,  
+Now these days, people all around the world are using it, They are happy with it, They go crazy with ``cmsplugin-simple-markdown``,  
 Even they name their child ``cmsplugin-simple-markdown``, At least I did. ;)

--- a/cmsplugin_simple_markdown/cms_plugins.py
+++ b/cmsplugin_simple_markdown/cms_plugins.py
@@ -7,16 +7,15 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from cmsplugin_simple_markdown.models import SimpleMarkdownPlugin
 from cms.utils.page_resolver import get_page_from_path
+from django_markdown.widgets import MarkdownWidget
 
 
 class SimpleMarkdownCMSPluginForm(forms.ModelForm):
+
     class Meta:
         model = SimpleMarkdownPlugin
         widgets = {
-            'markdown_text': forms.Textarea(
-                attrs={'cols': 100, 'rows': 20,
-                       'style': 'font-family: Monaco, monospace;'}
-            )
+            'markdown_text': MarkdownWidget
         }
 
 

--- a/cmsplugin_simple_markdown/migrations_django/0001_initial.py
+++ b/cmsplugin_simple_markdown/migrations_django/0001_initial.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0006_auto_20150419_0900'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SimpleMarkdownPlugin',
+            fields=[
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('markdown_text', models.TextField(verbose_name='text')),
+                ('template', models.CharField(default=b'cmsplugin_simple_markdown/simple_markdown.html', verbose_name='template', max_length=255, editable=False, choices=[(b'cmsplugin_simple_markdown/simple_markdown.html', b'simple_markdown.html')])),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('cms.cmsplugin',),
+        ),
+    ]

--- a/cmsplugin_simple_markdown/templates/cmsplugin_simple_markdown/simple_markdown.html
+++ b/cmsplugin_simple_markdown/templates/cmsplugin_simple_markdown/simple_markdown.html
@@ -1,2 +1,2 @@
-{% load markup %}
+{% load django_markdown %}
 {{ text|markdown }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django
 markdown
-django-markwhat
+django-markdown
 django-cms

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     install_requires=[
         'django',
         'markdown',
-        'django-markwhat',
+        'django-markdown',
         'django-cms'
     ],
     url='https://www.github.com/Alir3z4/cmsplugin-simple-markdown',


### PR DESCRIPTION
django.contrib.markup disappeared in Django 1.6 so we can't use it anymore.
Using a different markdown renderer is a must, [django_markdown](https://github.com/klen/django_markdown) is used here.
I can also change documentation if pull request gets accepted.