### PR TITLE
Made it work again

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,6 +20,7 @@ answer newbie questions, and generally made ``cmsplugin-simple-markdown`` that m
 * Philipp Bosch <hello@pb.io>
 * Igor Pejic <igor.pejic@dr.com>
 * Alex Wright <alex@xeentech.com>
+* Jannik Vieten <me@exploide.net>
 
 
 A big THANK YOU goes to:

--- a/README.rst
+++ b/README.rst
@@ -75,9 +75,11 @@ It's fucking hard to install.
 Configuration & Usage
 ----------------------
 
-1. Add ``cmsplugin_simple_markdown`` to  ``INSTALLED_APPS``.
-2. If you are using Django 1.7 add ``'cmsplugin_simple_markdown': 'cmsplugin_simple_markdown.migrations_django',`` to ``MIGRATION_MODULES`` in settings.
-3. Create the database tables::
+1. Make sure ``django-markdown`` is configured as described in their `Setup
+<https://github.com/klen/django_markdown#id5>`_ section.
+2. Add ``cmsplugin_simple_markdown`` to  ``INSTALLED_APPS``.
+3. If you are using Django 1.7 or higher add ``'cmsplugin_simple_markdown': 'cmsplugin_simple_markdown.migrations_django',`` to ``MIGRATION_MODULES`` in settings.
+4. Create the database tables::
 
     $ python manage.py migrate
 
@@ -93,5 +95,5 @@ Since every application won't begins with love, this plugin developed to solve a
 but when I've tried to use aws s3/cloudfront for my static files, I've stuck with ``CORS`` problem.
 So I've develop ``cmsplugin-simple-markdown`` to be used without any deps on js/css files.
 
-Now these days, people all around the world are using it, They are happy with it, They go crazy with ``cmsplugin-simple-markdown``,  
+Now these days, people all around the world are using it, They are happy with it, They go crazy with ``cmsplugin-simple-markdown``,
 Even they name their child ``cmsplugin-simple-markdown``, At least I did. ;)

--- a/cmsplugin_simple_markdown/cms_plugins.py
+++ b/cmsplugin_simple_markdown/cms_plugins.py
@@ -35,7 +35,7 @@ class SimpleMarkdownCMSPlugin(CMSPluginBase):
             else:
                 return "(#" + match.group(1) + ")"
 
-        return re.sub('\(page:([^\)]+)\)', link_repl, markdown_text)
+        return re.sub(r'\(page:([^\)]+)\)', link_repl, markdown_text)
 
     def render(self, context, instance, placeholder):
         context['text'] = self.replace_links(instance.markdown_text)

--- a/cmsplugin_simple_markdown/cms_plugins.py
+++ b/cmsplugin_simple_markdown/cms_plugins.py
@@ -14,6 +14,7 @@ class SimpleMarkdownCMSPluginForm(forms.ModelForm):
 
     class Meta:
         model = SimpleMarkdownPlugin
+        fields = '__all__'
         widgets = {
             'markdown_text': MarkdownWidget
         }

--- a/cmsplugin_simple_markdown/migrations_django/0001_initial.py
+++ b/cmsplugin_simple_markdown/migrations_django/0001_initial.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0006_auto_20150419_0900'),
+        ('cms', '0011_auto_20150419_1006'),
     ]
 
     operations = [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='cmsplugin-simple-markdown',
     version=".".join(map(str, __import__('cmsplugin_simple_markdown').__version__)),
-    packages=['cmsplugin_simple_markdown', 'cmsplugin_simple_markdown.migrations'],
+    packages=['cmsplugin_simple_markdown', 'cmsplugin_simple_markdown.migrations', 'cmsplugin_simple_markdown.migrations_django'],
     package_dir={'cmsplugin_simple_markdown': 'cmsplugin_simple_markdown'},
     package_data={'cmsplugin_simple_markdown': ['templates/*/*']},
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development'
     ],
 )


### PR DESCRIPTION
I fixed some issues to make the plugin work again.

* added migrations_django folder to setup.py - fixes #8
* migration dependency refers to an existing migration now - fixes #9
* made SimpleMarkdownCMSPluginForm Django 1.8 compatible
* string in regular expression is marked as a raw string now
* some README improvements
* mentioned Python 3 compatibility in setup.py

If you like it, all you have to do is bumping up the version number and publishing a new release on PyPi.