### PR TITLE
added leftover migration for Python3 compatibility

### DIFF
--- a/cmsplugin_simple_markdown/migrations_django/0002_auto_20160417_1727.py
+++ b/cmsplugin_simple_markdown/migrations_django/0002_auto_20160417_1727.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_simple_markdown', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='simplemarkdownplugin',
+            name='template',
+            field=models.CharField(choices=[('cmsplugin_simple_markdown/simple_markdown.html', 'simple_markdown.html')], max_length=255, editable=False, verbose_name='template', default='cmsplugin_simple_markdown/simple_markdown.html'),
+        ),
+    ]


### PR DESCRIPTION
Added a migration which occurs when using Python3. According to a short test, it still works with Python2, too.

would be good to see this in before #11 is resolved ;)