### PR TITLE
added new migration

### DIFF
--- a/cmsplugin_simple_markdown/migrations_django/0003_auto_20161022_1719.py
+++ b/cmsplugin_simple_markdown/migrations_django/0003_auto_20161022_1719.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_simple_markdown', '0002_auto_20160417_1727'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='simplemarkdownplugin',
+            name='cmsplugin_ptr',
+            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_simple_markdown_simplemarkdownplugin', primary_key=True, serialize=False, auto_created=True, to='cms.CMSPlugin'),
+        ),
+    ]


### PR DESCRIPTION
In the meantime, it seems that newer versions of django-cms let `makemigrations` create a new migration for cmsplugin-simple-markdown. To avoid the unmigrated changes warning in django-cms instances, this PR adds the new migration.

If you like to merge this, please also publish a new release on PyPi. :)
